### PR TITLE
docs: improve ETHID MCP quick setup instructions

### DIFF
--- a/pages/docs/ai-tools/ethid-mcp.mdx
+++ b/pages/docs/ai-tools/ethid-mcp.mdx
@@ -4,7 +4,17 @@ The ETHID MCP is a comprehensive Model Context Protocol server that provides sea
 
 ## Quick Setup
 
-### 1. Use the online server
+Choose one of the following options to set up ETHID MCP:
+
+### Option 1: Claude Code Setup
+
+For Claude Code users, simply run this command:
+
+```bash
+claude mcp add --transport sse ethid https://ethid-mcp.efp.workers.dev/sse
+```
+
+### Option 2: Use the online server
 
 Use one of the following endpoints to connect the MCP server to your AI assistant (Claude, Wireshark, ChatGPT, etc.).
 
@@ -16,7 +26,7 @@ https://ethid-mcp.efp.workers.dev/sse
 https://ethid-mcp.efp.workers.dev
 ```
 
-### 2. Run it locally
+### Option 3: Run it locally
 
 ```bash
 npm install


### PR DESCRIPTION
- Clarify that setup methods are options to choose from
- Add Claude Code setup as the first option with simple command
- Rename existing options for consistency

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Quick Setup into three clear options: Claude Code Setup, Use the online server, and Run it locally.
  * Added a concrete CLI command for Claude Code to configure the MCP transport to the SSE endpoint.
  * Clarified online server access with explicit SSE and HTTP endpoints shown in a dedicated code block.
  * Simplified local setup to a single install command, removing the previous additional step.
  * Overall, provides clearer, option-based guidance and streamlined setup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->