### PR TITLE
missed labels

### DIFF
--- a/public/llms/complete/llms-full.txt
+++ b/public/llms/complete/llms-full.txt
@@ -8,7 +8,7 @@
 
 **Is EFP a social network?**
 
-> No, EFP is just a social graph. It has no names or profiles (use [ENS](https://ens.domains/) for that), no authentication protocol (use [SIWE](https://login.xyz/)), nor posting or tweeting. It's a primitive of the Ethereum identity stack meant to be combined with others elements in that stack in third party apps. [This article](https://mirror.xyz/brantly.eth/7nJZCqyvhbdTIfq4oSnNEjlUUyxS9sf3pTHcBNi8Te8) explains the vision.
+> No, EFP is just a social graph. It has no names or profiles (use [ENS](https://ens.domains/) for that), no authentication protocol (use [SIWE](https://siwe.xyz/)), nor posting or tweeting. It's a primitive of the Ethereum identity stack meant to be combined with others elements in that stack in third party apps. [This article](https://mirror.xyz/brantly.eth/7nJZCqyvhbdTIfq4oSnNEjlUUyxS9sf3pTHcBNi8Te8) explains the vision.
 
 **Can I post or tweet on EFP?**
 
@@ -37785,12 +37785,12 @@ Create two files:
 `message.txt`:
 
 ```
-login.xyz wants you to sign in with your Ethereum account:
+siwe.xyz wants you to sign in with your Ethereum account:
 0xfA151B5453CE69ABf60f0dbdE71F6C9C5868800E
 
 Sign in with Ethereum Example Statement
 
-URI: https://login.xyz
+URI: https://siwe.xyz
 Version: 1
 Chain ID: 1
 Nonce: ToTaLLyRanDOM

--- a/public/llms/complete/llms.txt
+++ b/public/llms/complete/llms.txt
@@ -503,7 +503,7 @@
 
 ---
 
-# docs.login.xyz llms.txt
+# docs.siwe.xyz llms.txt
 
 > Offering resources and guidance for integrating Sign-In with Ethereum, enhancing user control over digital identities in web applications, while promoting best practices and supporting community involvement within the Ethereum ecosystem.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated SIWE references from login.xyz to siwe.xyz across LLMs documentation.
  - Adjusted links in the EFP overview paragraph to point to https://siwe.xyz/.
  - Revised the “Create two files: message.txt” example text to use siwe.xyz in the sign-in prompt and URI.
  - Renamed a documentation header from “docs.login.xyz” to “docs.siwe.xyz”.
  - No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->